### PR TITLE
Update info/1 directives for the preferred format for versions and dates in Logtalk 3.36.0

### DIFF
--- a/template/main.lgt
+++ b/template/main.lgt
@@ -1,9 +1,9 @@
 :- object(main).
 
 	:- info([
-		version is 0.1,
+		version is 0:1:0,
 		author is 'FULLNAME',
-		date is y/m/d,
+		date is year-month-day,
 		comment is 'Description'
 	]).
 

--- a/template/tests.lgt
+++ b/template/tests.lgt
@@ -2,9 +2,9 @@
 	extends(lgtunit)).
 
 	:- info([
-		version is 0.1,
+		version is 0:1:0,
 		author is 'FULLNAME',
-		date is y/m/d,
+		date is year-month-day,
 		comment is 'Description'
 	]).
 


### PR DESCRIPTION
Note that this pull request makes Logtalk 3.36.0 or later required.